### PR TITLE
README.md improvement for Open3D library installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,11 @@ gantt
 ## 3rd party libraries
 
 The project uses the following 3rd party libraries:
-- `Open3d 0.18.0` for 3D point cloud processing it needs to be installed from source [from here](https://github.com/isl-org/Open3D/releases/download/v0.18.0/open3d-devel-windows-amd64-0.18.0.zip), unzip the file and by following the instructions below:
+- `Open3d 0.18.0` for 3D point cloud processing it needs to be installed from source [from here](https://github.com/isl-org/Open3D/releases/download/v0.18.0/open3d-devel-windows-amd64-0.18.0.zip), unzip the file to `Program Files/Open3D`:
 ```terminal
-cd open3d
-mkdir build
-cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_INSTALL_PREFIX="C:\Program Files\Open3D" -S . -B build
-cmake --build build --config Release --target ALL_BUILD
-cmake --build build --config Release --target INSTALL
+Expand-Archive -DestinationPath 'C:\Users\localuser\Downloads' -LiteralPath "C:\Users\localuser\Downloads\open3d-devel-windows-amd64-0.18.0.zip"
+Move-Item -LiteralPath 'C:\Users\localuser\Downloads\open3d-devel-windows-amd64-0.18.0\*' -Destination 'C:\Program Files\Open3D\'
+rmdir 'C:\Users\localuser\Downloads\open3d-devel-windows-amd64-0.18.0\'
 ```
 - `Eigen` for linear algebra (needed by `Open3d`)
 - `CGAL` for general geometric processing and IO

--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ gantt
 ## 3rd party libraries
 
 The project uses the following 3rd party libraries:
-- `Open3d 0.18.0` for 3D point cloud processing it needs to be installed from source [from here](https://github.com/isl-org/Open3D/releases/download/v0.18.0/open3d-devel-windows-amd64-0.18.0.zip), unzip the file to `Program Files/Open3D`:
+- `Open3d 0.18.0` for 3D point cloud processing it needs to be installed from source [from here](https://github.com/isl-org/Open3D/releases/download/v0.18.0/open3d-devel-windows-amd64-0.18.0.zip), unzip the file to `Program Files/Open3D`. Change `<Your user name>` with your user name:
 ```terminal
-Expand-Archive -DestinationPath 'C:\Users\localuser\Downloads' -LiteralPath "C:\Users\localuser\Downloads\open3d-devel-windows-amd64-0.18.0.zip"
-Move-Item -LiteralPath 'C:\Users\localuser\Downloads\open3d-devel-windows-amd64-0.18.0\*' -Destination 'C:\Program Files\Open3D\'
-rmdir 'C:\Users\localuser\Downloads\open3d-devel-windows-amd64-0.18.0\'
+Expand-Archive -DestinationPath 'C:\Users\<Your user name>\Downloads' -LiteralPath "C:\Users\<Your user name>\Downloads\open3d-devel-windows-amd64-0.18.0.zip"
+Move-Item -LiteralPath 'C:\Users\<Your user name>\Downloads\open3d-devel-windows-amd64-0.18.0\*' -Destination 'C:\Program Files\Open3D\'
+rmdir 'C:\Users\<Your user name>\Downloads\open3d-devel-windows-amd64-0.18.0\'
 ```
 - `Eigen` for linear algebra (needed by `Open3d`)
 - `CGAL` for general geometric processing and IO

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ To build and test the project, follow the following steps:
 ```terminal
 cmake/config.bat
 cmake/build.bat
-./build/bin/diffCheckApp.exe <-- for prototyping
+./build/bin/Release/diffCheckApp.exe <-- for prototyping
 ```
 
 ## Prototype diffCheck in C++

--- a/README.md
+++ b/README.md
@@ -47,11 +47,13 @@ gantt
 ## 3rd party libraries
 
 The project uses the following 3rd party libraries:
-- `Open3d 0.18.0` for 3D point cloud processing it needs to be installed from source [from here](https://github.com/isl-org/Open3D/releases/download/v0.18.0/open3d-devel-windows-amd64-0.18.0.zip), unzip the file to `Program Files/Open3D`. Change `<Your user name>` with your user name:
+- `Open3d 0.18.0` for 3D point cloud processing it needs to be installed from source [from here](https://github.com/isl-org/Open3D/archive/refs/tags/v0.18.0.zip), unzip the file and by following the instructions below:
 ```terminal
-Expand-Archive -DestinationPath 'C:\Users\<Your user name>\Downloads' -LiteralPath "C:\Users\<Your user name>\Downloads\open3d-devel-windows-amd64-0.18.0.zip"
-Move-Item -LiteralPath 'C:\Users\<Your user name>\Downloads\open3d-devel-windows-amd64-0.18.0\*' -Destination 'C:\Program Files\Open3D\'
-rmdir 'C:\Users\<Your user name>\Downloads\open3d-devel-windows-amd64-0.18.0\'
+cd open3d
+mkdir build
+cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_INSTALL_PREFIX="C:\Program Files\Open3D" -S . -B build
+cmake --build build --config Release --target ALL_BUILD
+cmake --build build --config Release --target INSTALL
 ```
 - `Eigen` for linear algebra (needed by `Open3d`)
 - `CGAL` for general geometric processing and IO


### PR DESCRIPTION
Hi @9and3 , I tried to install Open3D following the instructions on the README.md but the files behind the link contains pre-built binaries and thus no CMakeLists.txt and cannot be built from source (and after building from source from the latest release I got linker issues ). With the changes proposed, the pre-built binaries are placed at the right place and link properly.