### PR TITLE
Test suite structure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,12 @@ list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 include(external_tools)
 include(options)
 
+# check that the -DCMAKE_BUILD_TYPE is set
+if(NOT CMAKE_BUILD_TYPE)
+    message(STATUS "Setting build type to 'Release' as none was specified.")
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build." FORCE)
+endif()
+
 # do a submodule init if not done already
 execute_process(COMMAND git submodule update --init --recursive
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
@@ -48,7 +54,7 @@ target_include_directories(${SHARED_LIB_NAME}
     PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src
     )
 
-    #set the MD_DynamicRelease flag for MSVC since we are compiling with /MD for py wrap
+#set the MD_DynamicRelease flag for MSVC since we are compiling with /MD for py wrap
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
 
 
@@ -146,31 +152,20 @@ if (BUILD_PYTHON_MODULE)
         $<TARGET_FILE:${PYBINDMODULE_NAME}>
         ${PYPI_DIR}
         )
-
-    # get all the files -dlls in the bin directory and copy them one by one to the pypi directory
-    file(GLOB files ${CMAKE_BINARY_DIR}/bin/Release/*.dll)
-    foreach(file ${files})
-        message(STATUS "Copying ${file} to ${TARGET_DLL_PYPI_DIR}")
-        add_custom_command(TARGET ${PYBINDMODULE_NAME} POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy
-            ${file}
-            ${TARGET_DLL_PYPI_DIR}
-            )
-    endforeach()
+    copy_dlls(${TARGET_DLL_PYPI_DIR} ${PYBINDMODULE_NAME})
 
 endif()
 
 #--------------------------------------------------------------------------
 # Tests
 #--------------------------------------------------------------------------
-
 include(CTest)
 enable_testing()
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/deps/googletest)
 set(TESTS_OUT_DIR ${CMAKE_BINARY_DIR}/df_tests/)
+set(TEST_OUT_DIR_BINARY ${TESTS_OUT_DIR}/${CMAKE_BUILD_TYPE})
 
-
-# Unit testing ------------------------------------------------------------
+# add new test suites .cc here
 set(UNIT_TESTS df_test_suites)
 add_executable(${UNIT_TESTS}
     tests/unit_tests/DFPointCloudTest.cc
@@ -179,40 +174,8 @@ add_executable(${UNIT_TESTS}
 set_target_properties(${UNIT_TESTS} PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${TESTS_OUT_DIR}
     )
-
 target_link_libraries(${UNIT_TESTS} gtest gtest_main)
 target_link_libraries(${UNIT_TESTS} ${SHARED_LIB_NAME})
 
 add_test(NAME ${UNIT_TESTS} COMMAND ${UNIT_TESTS})
-
-
-
-
-
-
-
-# # post build recipe
-# add_test(NAME ${UNIT_TEST} COMMAND ${UNIT_TEST})
-# add_custom_command(
-#      TARGET ${UNIT_TEST}
-#      COMMENT "Run tests"
-#      POST_BUILD 
-#      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-#      COMMAND ${CMAKE_CTEST_COMMAND} -C $<CONFIGURATION> -R "^${UNIT_TEST}$" --output-on-failures
-# )
-
-# Integration testing -----------------------------------------------------
-# Component testing -------------------------------------------------------
-# etc ---------------------------------------------------------------------
-
-# # TODO: a better way to copy the dlls to the tests directory for the tests
-# # get all the files -dlls in the bin directory and copy them one by one to tests dir
-# file(GLOB files ${CMAKE_BINARY_DIR}/bin/Release/*.dll)
-# foreach(file ${files})
-#     message(STATUS "Copying ${file} to ${TESTS_OUT_DIR}")
-#     add_custom_command(TARGET ${UNIT_TESTS} POST_BUILD
-#         COMMAND ${CMAKE_COMMAND} -E copy
-#         ${file}
-#         ${TESTS_OUT_DIR}/Release
-#         )
-# endforeach()
+copy_dlls(${TEST_OUT_DIR_BINARY} ${UNIT_TESTS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,23 +164,42 @@ endif()
 # Tests
 #--------------------------------------------------------------------------
 
-# include(CTest)
-# enable_testing()
-# add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/deps/googletest)
-# set(TESTS_OUT_DIR ${CMAKE_BINARY_DIR}/tests/)
+include(CTest)
+enable_testing()
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/deps/googletest)
+set(TESTS_OUT_DIR ${CMAKE_BINARY_DIR}/df_tests/)
 
 
-# # Unit testing ------------------------------------------------------------
-# set(UNIT_TESTS unit_tests)
-# add_executable(${UNIT_TESTS} tests/unit_tests/DFPointCloudTest.cc)
-# set_target_properties(${UNIT_TESTS} PROPERTIES
-#     RUNTIME_OUTPUT_DIRECTORY ${TESTS_OUT_DIR}
-#     )
+# Unit testing ------------------------------------------------------------
+set(UNIT_TESTS df_test_suites)
+add_executable(${UNIT_TESTS}
+    tests/unit_tests/DFPointCloudTest.cc
+    tests/entryTest.cc
+    )
+set_target_properties(${UNIT_TESTS} PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${TESTS_OUT_DIR}
+    )
 
-# target_link_libraries(${UNIT_TESTS} gtest gtest_main)
-# target_link_libraries(${UNIT_TESTS} ${SHARED_LIB_NAME})
+target_link_libraries(${UNIT_TESTS} gtest gtest_main)
+target_link_libraries(${UNIT_TESTS} ${SHARED_LIB_NAME})
 
-# add_test(NAME ${UNIT_TESTS} COMMAND ${UNIT_TESTS})
+add_test(NAME ${UNIT_TESTS} COMMAND ${UNIT_TESTS})
+
+
+
+
+
+
+
+# # post build recipe
+# add_test(NAME ${UNIT_TEST} COMMAND ${UNIT_TEST})
+# add_custom_command(
+#      TARGET ${UNIT_TEST}
+#      COMMENT "Run tests"
+#      POST_BUILD 
+#      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+#      COMMAND ${CMAKE_CTEST_COMMAND} -C $<CONFIGURATION> -R "^${UNIT_TEST}$" --output-on-failures
+# )
 
 # Integration testing -----------------------------------------------------
 # Component testing -------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,7 @@ target_link_libraries(${SHARED_LIB_NAME} PUBLIC Open3D::Open3D)
 if(WIN32)
     get_target_property(open3d_type Open3D::Open3D TYPE)
     if(open3d_type STREQUAL "SHARED_LIBRARY")
-        message(STATUS "Copying Open3D.dll to ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>")
+        message(STATUS "Copying Open3D.dll to ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}")
         add_custom_command(TARGET ${SHARED_LIB_NAME} POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E copy
             $<TARGET_FILE:Open3D::Open3D>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -328,3 +328,7 @@ To run the tests from terminal
 ```
 ctest --test-dir .\build\ -C Release -V
 ```
+or
+```
+.\build\df_tests\<config>\df_tests.exe
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -320,43 +320,11 @@ dfVisualizerPtr->Run();
 
 
 ### CTesting (TO BE UPDATED)
-When necessary, c++ testing is done by using CTest. Important/critical features (e.g., correcting functioning of graphics with OpenGL and Glfw) needs testing to be written (this is usefull for e.g., GitHub Actions). Such tests can be extracted from the main source code and integrated in a seperate section: cmake testing.
+Tests in df are all `.cc` files added to the `tests` source files, all the data needs to be contained in `tests/test_data`. Finally add your `.cc` files in the cmake:
 
-To add a new test do as follow.
+https://github.com/diffCheckOrg/diffCheck/blob/efb10e0b5685a1ef1537d0309388f642075d3244/CMakeLists.txt#L170-L173
 
-First create a new sub-folder in the folder `./test` as `./test/exampletest`.
-Here add a console cpp file called `tester.cpp` which returns 0 or 1 and add a new `CMakeLists.txt` as such:
-```cmake
-add_executable(example_test tester.cpp)
-
-/* <-- 
-Insert here linking necessary for the executable
-Note that if you already found packages in the head CMakeLists file
-you can simply use the macros here.
---> */
-
-add_test(NAME "ExampleTest" COMMAND "example_test" <argv-here> WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+To run the tests from terminal
 ```
-In the `./test`'s `CMakeLists.txt` add the created sub-directory:
-```cmake
-if (TEST_EXAMPLE)
-    add_subdirectory(exampletest)
-endif()
-```
-Finally add an option in the main `CMakeLists.txt` describing the test:
-```cmake
-include(CTest)
-# ...
-option(TEST_EXAMPLE "Test to test something important." ON)
-# ...
-if(TEST_EXAMPLE)
-    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tests/exampletest)
-endif()
-```
-
-Next, `./configure.sh -c` and `./build.sh` and:
-```bash
-cd ./build
-ctest -N    # <--- to see how many tests there are
-ctest -V    # <--- run the tests
+ctest --test-dir .\build\ -C Release -V
 ```

--- a/cmake/__noenv__config.bat
+++ b/cmake/__noenv__config.bat
@@ -1,2 +1,2 @@
 REM configure the project
-cmake -S . -B build
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release

--- a/cmake/clean_config.bat
+++ b/cmake/clean_config.bat
@@ -5,4 +5,4 @@ REM clean the build directory and reconfigure it
 rmdir /s /q build
 
 REM configure the project
-cmake -S . -B build
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release

--- a/cmake/config.bat
+++ b/cmake/config.bat
@@ -2,4 +2,4 @@ REM activate the conda diff_check environment otherwise the python wrap won't wo
 call cmake/activate_conda.bat
 
 REM configure the project
-cmake -S . -B build
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release

--- a/cmake/external_tools.cmake
+++ b/cmake/external_tools.cmake
@@ -229,3 +229,22 @@ function(download_submodule_project project_name)
     message(FATAL_ERROR "git submodule update --init --recursive --remote failed with ${GIT_SUBMOD_RESULT}, please checkout submodules")
   endif()
 endfunction()
+
+# ------------------------------------------------------------------------------
+function (copy_dlls directory_to_copy_dlls post_build_target)
+  message (STATUS "Erasing old DLLs and copy new ones to ${directory_to_copy_dlls}")
+  file(GLOB files ${directory_to_copy_dlls}/*.dll)
+  foreach(file ${files})
+      message(STATUS "Removing ${file}")
+      file(REMOVE ${file})
+  endforeach()
+  file(GLOB files ${CMAKE_BINARY_DIR}/bin/${CMAKE_BUILD_TYPE}/*.dll)
+  foreach(file ${files})
+      message(STATUS "Copying ${file} to ${directory_to_copy_dlls}")
+      add_custom_command(TARGET ${post_build_target} POST_BUILD
+          COMMAND ${CMAKE_COMMAND} -E copy
+          ${file}
+          ${directory_to_copy_dlls}
+          )
+  endforeach()
+endfunction()

--- a/src/diffCheckApp.cc
+++ b/src/diffCheckApp.cc
@@ -12,39 +12,39 @@ int main()
   std::shared_ptr<diffCheck::geometry::DFMesh> dfMeshPtr 
       = std::make_shared<diffCheck::geometry::DFMesh>();
 
-  // create a sphere from o3d
-  std::string pathCloud = R"(C:\andre\Downloads\moved_04.ply)";
-  std::string pathMesh = R"(C:\Users\andre\Downloads\meshtest.ply)";
+  // // create a sphere from o3d
+  // std::string pathCloud = R"(C:\andre\Downloads\moved_04.ply)";
+  // std::string pathMesh = R"(C:\Users\andre\Downloads\meshtest.ply)";
 
-  // dfPointCloudPtr->LoadFromPLY(pathCloud);
-  dfMeshPtr->LoadFromPLY(pathMesh);
+  // // dfPointCloudPtr->LoadFromPLY(pathCloud);
+  // dfMeshPtr->LoadFromPLY(pathMesh);
 
-  open3d::geometry::TriangleMesh meshO3d = *dfMeshPtr->Cvt2O3DTriangleMesh();
-
-
-  // convert the sphere to a diffCheck point cloud
-  // auto o3dPointCloud = meshO3d.SamplePointsUniformly(1000);
-
-  std::shared_ptr<open3d::geometry::PointCloud> tightBBOX = std::make_shared<open3d::geometry::PointCloud>();
-
-  // compute the bounding box
-  open3d::geometry::OrientedBoundingBox bbox = meshO3d.GetMinimalOrientedBoundingBox();
-  std::vector<Eigen::Vector3d> bboxPts = bbox.GetBoxPoints();
-  for (auto &pt : bboxPts)
-  {
-    tightBBOX->points_.push_back(pt);
-  }
+  // open3d::geometry::TriangleMesh meshO3d = *dfMeshPtr->Cvt2O3DTriangleMesh();
 
 
-  dfPointCloudPtr->Cvt2DFPointCloud(tightBBOX);
+  // // convert the sphere to a diffCheck point cloud
+  // // auto o3dPointCloud = meshO3d.SamplePointsUniformly(1000);
+
+  // std::shared_ptr<open3d::geometry::PointCloud> tightBBOX = std::make_shared<open3d::geometry::PointCloud>();
+
+  // // compute the bounding box
+  // open3d::geometry::OrientedBoundingBox bbox = meshO3d.GetMinimalOrientedBoundingBox();
+  // std::vector<Eigen::Vector3d> bboxPts = bbox.GetBoxPoints();
+  // for (auto &pt : bboxPts)
+  // {
+  //   tightBBOX->points_.push_back(pt);
+  // }
+
+
+  // dfPointCloudPtr->Cvt2DFPointCloud(tightBBOX);
 
 
 
 
-  std::shared_ptr<diffCheck::visualizer::Visualizer> vis = std::make_shared<diffCheck::visualizer::Visualizer>();
-  vis->AddPointCloud(dfPointCloudPtr);
-  // vis->AddMesh(dfMeshPtr);
-  vis->Run();
+  // std::shared_ptr<diffCheck::visualizer::Visualizer> vis = std::make_shared<diffCheck::visualizer::Visualizer>();
+  // vis->AddPointCloud(dfPointCloudPtr);
+  // // vis->AddMesh(dfMeshPtr);
+  // vis->Run();
 
 
   return 0;

--- a/tests/entryTest.cc
+++ b/tests/entryTest.cc
@@ -8,8 +8,6 @@ TEST(AddTest, HandlesPositiveInput) {
     EXPECT_EQ(6, add(2, 4));
 }
 
-
-
 int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/tests/entryTest.cc
+++ b/tests/entryTest.cc
@@ -1,16 +1,15 @@
 #include <gtest/gtest.h>
 
-// Function to test
 int add(int a, int b) {
     return a + b;
 }
 
-// Test case
 TEST(AddTest, HandlesPositiveInput) {
     EXPECT_EQ(6, add(2, 4));
 }
 
-// Main function
+
+
 int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/tests/unit_tests/DFPointCloudTest.cc
+++ b/tests/unit_tests/DFPointCloudTest.cc
@@ -1,21 +1,55 @@
 #include <gtest/gtest.h>
 #include "diffCheck.hh"
 
+class DFPointCloudTestFixture : public ::testing::Test {
+protected:
+    std::vector<Eigen::Vector3d> points;
+    std::vector<Eigen::Vector3d> colors;
+    std::vector<Eigen::Vector3d> normals;
+    diffCheck::geometry::DFPointCloud dfPointCloud;
 
-TEST(DFPointCloudTest, TestConstructor) {
-    std::vector<Eigen::Vector3d> points = {Eigen::Vector3d(1, 2, 3)};
-    std::vector<Eigen::Vector3d> colors = {Eigen::Vector3d(255, 255, 255)};
-    std::vector<Eigen::Vector3d> normals = {Eigen::Vector3d(0, 0, 1)};
+    DFPointCloudTestFixture() : dfPointCloud(points, colors, normals) {}
 
-    diffCheck::geometry::DFPointCloud dfPointCloud(points, colors, normals);
+    void SetUp() override {
+        // Initialize your objects and variables here
+        points = {Eigen::Vector3d(1, 2, 3)};
+        colors = {Eigen::Vector3d(255, 255, 255)};
+        normals = {Eigen::Vector3d(0, 0, 1)};
 
-    // Verify that the points, colors, and normals are set correctly
-    EXPECT_EQ(dfPointCloud.Points[0], points[0]);
-    EXPECT_EQ(dfPointCloud.Colors[0], colors[0]);
-    EXPECT_EQ(dfPointCloud.Normals[0], normals[0]);
+        // Reinitialize dfPointCloud in case you need to reset its state
+        dfPointCloud = diffCheck::geometry::DFPointCloud(points, colors, normals);
+    }
+
+    void TearDown() override {
+        // Clean up any resources if needed
+    }
+};
+
+TEST_F(DFPointCloudTestFixture, GetNumPoints) {
+    EXPECT_EQ(dfPointCloud.GetNumPoints(), 1);
 }
 
-int main(int argc, char **argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
+TEST_F(DFPointCloudTestFixture, GetNumColors) {
+    EXPECT_EQ(dfPointCloud.GetNumColors(), 1);
 }
+
+TEST_F(DFPointCloudTestFixture, GetNumNormals) {
+    EXPECT_EQ(dfPointCloud.GetNumNormals(), 1);
+}
+
+TEST_F(DFPointCloudTestFixture, HasPoints) {
+    EXPECT_TRUE(dfPointCloud.HasPoints());
+}
+
+TEST_F(DFPointCloudTestFixture, HasColors) {
+    EXPECT_TRUE(dfPointCloud.HasColors());
+}
+
+TEST_F(DFPointCloudTestFixture, HasNormals) {
+    EXPECT_TRUE(dfPointCloud.HasNormals());
+}
+
+// int main(int argc, char **argv) {
+//     ::testing::InitGoogleTest(&argc, argv);
+//     return RUN_ALL_TESTS();
+// }


### PR DESCRIPTION
This PR proposes a structure for integrating test fixtures and suites for df. 
Tests in df are all `.cc` files added to the `tests` source files, all the data needs to be contained in `tests/test_data`. Finally add your `.cc` files in the cmake:

https://github.com/diffCheckOrg/diffCheck/blob/efb10e0b5685a1ef1537d0309388f642075d3244/CMakeLists.txt#L170-L173


To run the tests from terminal
```
ctest --test-dir .\build\ -C Release -V
```

> ☠️  It also patches a copying .dlls problem with the cmake file. It should fix the following issues all related to it: #30 , #29 , #25 