### PR TITLE
refactoring segmentations with DFAsssembly

### DIFF
--- a/src/gh/components/DF_CAD_segmentator/code.py
+++ b/src/gh/components/DF_CAD_segmentator/code.py
@@ -38,7 +38,7 @@ class DFCADSegmentator(component):
         o_clusters = []
         # the df cloud clusters
         df_clusters = []
-        # we make a deepcopy of the input clouds because 
+        # we make a deepcopy of the input clouds
         df_clouds = [df_cvt_bindings.cvt_rhcloud_2_dfcloud(cloud.Duplicate()) for cloud in i_clouds]
 
         df_beams = i_assembly.beams
@@ -73,11 +73,11 @@ class DFCADSegmentator(component):
 
         return o_clusters, rh_beams_meshes
 
-if __name__ == "__main__":
-    com = DFCADSegmentator()
-    o_clusters, rh_beams_meshes = com.RunScript(
-        i_clouds,
-        i_assembly,
-        i_angle_threshold,
-        i_association_threshold
-        )
+# if __name__ == "__main__":
+#     com = DFCADSegmentator()
+#     o_clusters, rh_beams_meshes = com.RunScript(
+#         i_clouds,
+#         i_assembly,
+#         i_angle_threshold,
+#         i_association_threshold
+#         )

--- a/src/gh/components/DF_joint_segmentator/code.py
+++ b/src/gh/components/DF_joint_segmentator/code.py
@@ -15,23 +15,14 @@ import typing
 ABSTOL = Rhino.RhinoDoc.ActiveDoc.ModelAbsoluteTolerance
 
 class DFJointSegmentator(component):
-    # def __init__(self):
-    #     super(DFJointSegmentator, self).__init__()
+    def __init__(self):
+        super(DFJointSegmentator, self).__init__()
     def RunScript(self, 
                   i_clusters: typing.List[Rhino.Geometry.PointCloud], 
                   i_assembly: diffCheck.df_geometries.DFAssembly,
                   i_angle_threshold: float,
                   i_distance_threshold: float):
-        """
-        Amongst clusters, associates the clusters to the individual joints, 
-        creates a reference point cloud for each joint, 
-        and returns the joint segments, the reference point clouds, and the ICP transformations from the first to the second.
 
-        :param i_clusters: The clusters to be associated to the joints.
-        :param i_assembly: The DFAssembly containing the joints we want to segment.
-        :param i_angle_threshold: The angle threshold for the association of the clusters to the joints.
-        :param i_distance_threshold: The distance threshold for the association of the clusters to the joints.
-        """
         if i_angle_threshold is None : i_angle_threshold = 0.1
         if i_distance_threshold is None : i_distance_threshold = 0.1
         
@@ -45,44 +36,44 @@ class DFJointSegmentator(component):
         n_joints = i_assembly.total_number_joints
 
         # prepping the reference meshes
-        joints = [[] for _ in range(n_joints)]
+        df_joints = [[] for _ in range(n_joints)]
         for joint in i_assembly.all_joints:
             for face in joint.faces:
                 face = face.to_mesh()
                 face.Subdivide()
                 face.Faces.ConvertQuadsToTriangles()
-                joints[joint.id].append(df_cvt.cvt_rhmesh_2_dfmesh(face))
+                df_joints[joint.id].append(df_cvt.cvt_rhmesh_2_dfmesh(face))
 
-        joint_clouds = []
+        ref_rh_joint_clouds = []
         transforms = []
-        joint_segments = []
-        df_clouds = [df_cvt.cvt_rhcloud_2_dfcloud(cluster) for cluster in i_clusters]
+        rh_joint_segments = []
+        df_cloud_clusters = [df_cvt.cvt_rhcloud_2_dfcloud(cluster) for cluster in i_clusters]
 
         # for each joint, find the corresponding clusters and merge them, generate a reference point cloud, and register the merged clusters to the reference point cloud
-        for joint in joints:
+        for df_joint in df_joints:
             # create the reference point cloud
-            joint_cloud = diffcheck_bindings.dfb_geometry.DFPointCloud()
+            ref_df_joint_cloud = diffcheck_bindings.dfb_geometry.DFPointCloud()
 
-            for face in joint:
-                face_cloud = face.sample_points_uniformly(1000)
-                joint_cloud.add_points(face_cloud)
+            for face in df_joint:
+                ref_face_cloud = face.sample_points_uniformly(1000)
+                ref_df_joint_cloud.add_points(ref_face_cloud)
 
-            joint_clouds.append(df_cvt.cvt_dfcloud_2_rhcloud(joint_cloud))
+            ref_rh_joint_clouds.append(df_cvt.cvt_dfcloud_2_rhcloud(ref_df_joint_cloud))
 
             # find the corresponding clusters and merge them
-            segment = diffcheck_bindings.dfb_segmentation.DFSegmentation.associate_clusters(joint, df_clouds, i_angle_threshold, i_distance_threshold)
-            diffcheck_bindings.dfb_segmentation.DFSegmentation.clean_unassociated_clusters(df_clouds, [segment], [joint], i_angle_threshold, i_distance_threshold)
+            df_joint_segment = diffcheck_bindings.dfb_segmentation.DFSegmentation.associate_clusters(df_joint, df_cloud_clusters, i_angle_threshold, i_distance_threshold)
+            diffcheck_bindings.dfb_segmentation.DFSegmentation.clean_unassociated_clusters(df_cloud_clusters, [df_joint_segment], [df_joint], i_angle_threshold, i_distance_threshold)
             
             # register the merged clusters to the reference point cloud
-            registration = diffcheck_bindings.dfb_registrations.DFRefinedRegistration.O3DICP(segment, joint_cloud)
+            registration = diffcheck_bindings.dfb_registrations.DFRefinedRegistration.O3DICP(df_joint_segment, ref_df_joint_cloud)
             res = registration.transformation_matrix
             transforms.append(df_cvt.cvt_ndarray_2_rh_transform(res))
-            joint_segments.append(df_cvt.cvt_dfcloud_2_rhcloud(segment))
+            rh_joint_segments.append(df_cvt.cvt_dfcloud_2_rhcloud(df_joint_segment))
         
         o_joint_segments = []
         o_transforms = []
         o_reference_point_clouds = []
-        for  joint_segment, transform, _joint_cloud in zip(joint_segments, transforms, joint_clouds):
+        for  joint_segment, transform, _joint_cloud in zip(rh_joint_segments, transforms, ref_rh_joint_clouds):
             if joint_segment.IsValid:
                 o_joint_segments.append(joint_segment)
                 o_transforms.append(transform)

--- a/src/gh/components/DF_joint_segmentator/code.py
+++ b/src/gh/components/DF_joint_segmentator/code.py
@@ -7,15 +7,19 @@ from diffCheck import diffcheck_bindings
 from diffCheck import df_cvt_bindings as df_cvt
 import diffCheck.df_util
 
+from Grasshopper.Kernel import GH_RuntimeMessageLevel as RML
 from ghpythonlib.componentbase import executingcomponent as component
+
+import typing
 
 ABSTOL = Rhino.RhinoDoc.ActiveDoc.ModelAbsoluteTolerance
 
 class DFJointSegmentator(component):
+    # def __init__(self):
+    #     super(DFJointSegmentator, self).__init__()
     def RunScript(self, 
-                  i_clusters: Rhino.Geometry.PointCloud, 
-                  i_joints: Rhino.Geometry.Mesh, 
-                  i_joint_ids: int,
+                  i_clusters: typing.List[Rhino.Geometry.PointCloud], 
+                  i_assembly: diffCheck.df_geometries.DFAssembly,
                   i_angle_threshold: float,
                   i_distance_threshold: float):
         """
@@ -24,16 +28,12 @@ class DFJointSegmentator(component):
         and returns the joint segments, the reference point clouds, and the ICP transformations from the first to the second.
 
         :param i_clusters: The clusters to be associated to the joints.
-        :param i_joints: The joints to which the clusters will be associated. These are meshes.
-        :param i_joint_ids: The joint ids of the joints.
+        :param i_assembly: The DFAssembly containing the joints we want to segment.
         :param i_angle_threshold: The angle threshold for the association of the clusters to the joints.
         :param i_distance_threshold: The distance threshold for the association of the clusters to the joints.
         """
         if i_angle_threshold is None : i_angle_threshold = 0.1
         if i_distance_threshold is None : i_distance_threshold = 0.1
-
-        if len(i_joints) != len(i_joint_ids):
-            raise ValueError("The number of joints and joint ids must be the same.")
         
         if len(i_clusters) == 0:
             raise ValueError("No clusters given.")
@@ -41,26 +41,29 @@ class DFJointSegmentator(component):
         if not isinstance(i_clusters[0], Rhino.Geometry.PointCloud):
             raise ValueError("The input clusters must be PointClouds.")
         
-        if not isinstance(i_joints[0], Rhino.Geometry.Mesh):
+        all_joints = i_assembly.all_joints
+        if not isinstance(all_joints[0].faces[0].to_mesh(), Rhino.Geometry.Mesh):
             raise ValueError("The input joints must be convertible to Meshes.")
             
+        # get number of joints
+        n_joints = max([joint.id for joint in all_joints]) + 1
 
         # prepping the reference meshes
-        n_joints = max(i_joint_ids) + 1
-        joints = [ [] for i in range(n_joints) ]
-        for face, id in zip(i_joints, i_joint_ids):
-            face.Subdivide()
-            face.Faces.ConvertQuadsToTriangles()
-            joints[id].append(df_cvt.cvt_rhmesh_2_dfmesh(face))
+        joints = [[] for _ in range(n_joints)]
+        for joint in all_joints:
+            for face in joint.faces:
+                face = face.to_mesh()
+                face.Subdivide()
+                face.Faces.ConvertQuadsToTriangles()
+                joints[joint.id].append(df_cvt.cvt_rhmesh_2_dfmesh(face))
 
         joint_clouds = []
-        registrations = []
+        transforms = []
         joint_segments = []
         df_clouds = [df_cvt.cvt_rhcloud_2_dfcloud(cluster) for cluster in i_clusters]
 
         # for each joint, find the corresponding clusters and merge them, generate a reference point cloud, and register the merged clusters to the reference point cloud
         for joint in joints:
-
             # create the reference point cloud
             joint_cloud = diffcheck_bindings.dfb_geometry.DFPointCloud()
 
@@ -72,19 +75,29 @@ class DFJointSegmentator(component):
 
             # find the corresponding clusters and merge them
             segment = diffcheck_bindings.dfb_segmentation.DFSegmentation.associate_clusters(joint, df_clouds, i_angle_threshold, i_distance_threshold)
-            diffcheck_bindings.dfb_segmentation.DFSegmentation.clean_unassociated_clusters(df_clouds, [segment], [joint], i_angle_threshold ,i_distance_threshold)
-
+            diffcheck_bindings.dfb_segmentation.DFSegmentation.clean_unassociated_clusters(df_clouds, [segment], [joint], i_angle_threshold, i_distance_threshold)
+            
             # register the merged clusters to the reference point cloud
             registration = diffcheck_bindings.dfb_registrations.DFRefinedRegistration.O3DICP(segment, joint_cloud)
             res = registration.transformation_matrix
-
-            registrations.append(df_cvt.cvt_ndarray_2_rh_transform(res))
+            transforms.append(df_cvt.cvt_ndarray_2_rh_transform(res))
             joint_segments.append(df_cvt.cvt_dfcloud_2_rhcloud(segment))
+        
+        o_joint_segments = []
+        o_transforms = []
+        o_reference_point_clouds = []
+        for  joint_segment, transform, _joint_cloud in zip(joint_segments, transforms, joint_clouds):
+            if joint_segment.IsValid:
+                o_joint_segments.append(joint_segment)
+                o_transforms.append(transform)
+                o_reference_point_clouds.append(_joint_cloud)
+            else:
+                ghenv.Component.AddRuntimeMessage(RML.Warning, "Some joints could not be segmented and were ignored.")
 
-        return joint_segments, registrations, joint_clouds
+        return o_joint_segments, o_transforms, o_reference_point_clouds
 
 # if __name__ == "__main__":
-#     o_joint_segments, o_reference_point_clouds, o_transforms = main(i_clusters, i_joints, i_joint_ids)
-
+#     comp = DFJointSegmentator()
+#     o_joint_segments, o_transforms, o_reference_point_clouds = comp.RunScript(i_clusters, i_assembly, i_angle_threshold, i_distance_threshold)
 #     for i in range(len(o_joint_segments)):
 #         o_joint_segments[i].Transform(o_transforms[i])

--- a/src/gh/components/DF_joint_segmentator/code.py
+++ b/src/gh/components/DF_joint_segmentator/code.py
@@ -40,17 +40,13 @@ class DFJointSegmentator(component):
 
         if not isinstance(i_clusters[0], Rhino.Geometry.PointCloud):
             raise ValueError("The input clusters must be PointClouds.")
-        
-        all_joints = i_assembly.all_joints
-        if not isinstance(all_joints[0].faces[0].to_mesh(), Rhino.Geometry.Mesh):
-            raise ValueError("The input joints must be convertible to Meshes.")
             
         # get number of joints
-        n_joints = max([joint.id for joint in all_joints]) + 1
+        n_joints = i_assembly.total_number_joints
 
         # prepping the reference meshes
         joints = [[] for _ in range(n_joints)]
-        for joint in all_joints:
+        for joint in i_assembly.all_joints:
             for face in joint.faces:
                 face = face.to_mesh()
                 face.Subdivide()

--- a/src/gh/components/DF_joint_segmentator/metadata.json
+++ b/src/gh/components/DF_joint_segmentator/metadata.json
@@ -13,7 +13,6 @@
         "marshalOutGuids": true,
         "iconDisplay": 2,
         "inputParameters": [
-            
             {
                 "name": "i_clusters",
                 "nickname": "i_clusters",
@@ -27,28 +26,16 @@
                 "typeHintID": "pointcloud"
             },
             {
-                "name": "i_joint_faces",
-                "nickname": "i_joint_faces",
-                "description": "The joints to extract and analyze",
+                "name": "i_assembly",
+                "nickname": "i_assembly",
+                "description": "The assembly to extract the joints from",
                 "optional": false,
                 "allowTreeAccess": false,
                 "showTypeHints": true,
-                "scriptParamAccess": "list",
+                "scriptParamAccess": "item",
                 "wireDisplay": "default",
                 "sourceCount": 0,
-                "typeHintID": "mesh"
-            },
-            {
-                "name": "i_joint_ids",
-                "nickname": "i_joint_ids",
-                "description": "The joint ids of the assembly",
-                "optional": false,
-                "allowTreeAccess": true,
-                "showTypeHints": true,
-                "scriptParamAccess": "list",
-                "wireDisplay": "default",
-                "sourceCount": 0,
-                "typeHintID": "int"
+                "typeHintID": "ghdoc"
             },
             {
                 "name": "i_angle_threshold",

--- a/src/gh/diffCheck/diffCheck/df_geometries.py
+++ b/src/gh/diffCheck/diffCheck/df_geometries.py
@@ -430,21 +430,21 @@ class DFAssembly:
 
     @property
     def all_joint_faces(self):
-        if len(self._all_jointfaces) == 0:
-            for beam in self.beams:
-                self._all_jointfaces.extend(beam.joint_faces)
+        self._all_jointfaces = []
+        for beam in self.beams:
+            self._all_jointfaces.extend(beam.joint_faces)
         return self._all_jointfaces
 
     @property
     def all_side_faces(self):
-        if len(self._all_sidefaces) == 0:
-            for beam in self.beams:
-                self._all_sidefaces.extend(beam.side_faces)
+        self._all_sidefaces = []
+        for beam in self.beams:
+            self._all_sidefaces.extend(beam.side_faces)
         return self._all_sidefaces
 
     @property
     def all_joints(self):
-        if len(self._all_joints) == 0:
-            for beam in self.beams:
-                self._all_joints.extend(beam.joints)
+        self._all_joints = []
+        for beam in self.beams:
+            self._all_joints.extend(beam.joints)
         return self._all_joints

--- a/src/gh/diffCheck/diffCheck/df_geometries.py
+++ b/src/gh/diffCheck/diffCheck/df_geometries.py
@@ -422,18 +422,21 @@ class DFAssembly:
 
     @property
     def all_joint_faces(self):
-        for beam in self.beams:
-            self._all_jointfaces.extend(beam.joint_faces)
+        if len(self._all_jointfaces) == 0:
+            for beam in self.beams:
+                self._all_jointfaces.extend(beam.joint_faces)
         return self._all_jointfaces
 
     @property
     def all_side_faces(self):
-        for beam in self.beams:
-            self._all_sidefaces.extend(beam.side_faces)
+        if len(self._all_sidefaces) == 0:
+            for beam in self.beams:
+                self._all_sidefaces.extend(beam.side_faces)
         return self._all_sidefaces
 
     @property
     def all_joints(self):
-        for beam in self.beams:
-            self._all_joints.extend(beam.joints)
+        if len(self._all_joints) == 0:
+            for beam in self.beams:
+                self._all_joints.extend(beam.joints)
         return self._all_joints

--- a/src/gh/diffCheck/diffCheck/df_geometries.py
+++ b/src/gh/diffCheck/diffCheck/df_geometries.py
@@ -314,6 +314,10 @@ class DFBeam:
         return self.__id
 
     @property
+    def number_joints(self):
+        return max([joint.id for joint in self.joints]) + 1
+
+    @property
     def joint_faces(self):
         return [face for face in self.faces if face.is_joint]
 
@@ -419,6 +423,10 @@ class DFAssembly:
 
         with open(file_path, "w") as f:
             f.write(pretty_xml)
+
+    @property
+    def total_number_joints(self):
+        return max([joint.id for joint in self.all_joints]) + 1
 
     @property
     def all_joint_faces(self):


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0b656f6f-63a2-4edc-88bd-a5725976cab4)
This PR concerns a small refactoring on the DFJoint_Segmentator component, to use DFAssembly instead of joint meshes and indexes passed separately. Sorry it took so long...
I also added a small runtime warning message is not all the joints could be segmented, for example if the scan did not cover completely the model.