### PR TITLE
fix color issue

### DIFF
--- a/src/gh/diffCheck/diffCheck/df_cvt_bindings.py
+++ b/src/gh/diffCheck/diffCheck/df_cvt_bindings.py
@@ -84,7 +84,9 @@ def cvt_dfcloud_2_rhcloud(df_cloud):
     elif df_cloud.has_normals():
         rh_cloud.AddRange(df_cloud_points, df_cloud_normals)
     elif df_cloud.has_colors():
-        rh_cloud.AddRange(df_cloud_points, df_cloud_colors)
+        rh_cloud.AddRange(df_cloud_points)
+        for i, color in enumerate(df_cloud_colors):
+            rh_cloud[i].Color = color
     else:
         rh_cloud.AddRange(df_cloud_points)
 


### PR DESCRIPTION
This tiny PR concerns the color issue that is due to overloading problem: 

RhinoCommons has an overloading with two AddRange methods that both thake two lists: one with locations and normals, ans the other with locations and colors. But when using the method with locations and colors, the one with locations and normals is called, triggering an error of conversion between RGB values and vector of doubles.
![image](https://github.com/user-attachments/assets/cdea1e24-cda1-4073-ab9b-6cf32c7589fe)

The fix first creates a point cloud with the locations, then adds the colors afterwards. It's a workaround, but it works.
![image](https://github.com/user-attachments/assets/b4fc2a8f-ddb9-4bd5-8c73-b01b163a16bc)
