### PR TITLE
FIX to DFCloud2Mesh 

### DIFF
--- a/src/gh/components/DF_cloud_mesh_distance/code.py
+++ b/src/gh/components/DF_cloud_mesh_distance/code.py
@@ -1,4 +1,6 @@
+"""Computes the distance between a point cloud and a mesh"""
 #! python3
+# r: diffCheck==1.0.0
 
 import Rhino
 import Grasshopper
@@ -46,13 +48,8 @@ class DFCloudMeshDistance(component):
             ghenv.Component.AddRuntimeMessage(RML.Warning, "The input number of objects to compare matches neither the number of beams nor the number of joints")  # noqa: F821
             return None, None, None, None, None, None
 
-        # conversion
-        siffed_df_cloud_source_list = []
-        siffed_rh_mesh_target_list = []
-        for i in range(len(i_cloud_source)):
-            if i_cloud_source[i] is not None:
-                siffed_df_cloud_source_list.append(df_cvt_bindings.cvt_rhcloud_2_dfcloud(i_cloud_source[i]))
-                siffed_rh_mesh_target_list.append(rh_mesh_target_list[i])
+        #conversion to DFCloud
+        df_cloud_source_list = [df_cvt_bindings.cvt_rhcloud_2_dfcloud(rh_cloud) for rh_cloud in i_cloud_list]
 
         # calculate distances
         o_result = df_error_estimation.df_cloud_2_rh_mesh_comparison(i_assembly, df_cloud_source_list, rh_mesh_target_list, i_signed_flag, i_swap)  # noqa: F821

--- a/src/gh/components/DF_cloud_mesh_distance/metadata.json
+++ b/src/gh/components/DF_cloud_mesh_distance/metadata.json
@@ -20,7 +20,7 @@
                 "optional": true,
                 "allowTreeAccess": true,
                 "showTypeHints": true,
-                "scriptParamAccess": "list",
+                "scriptParamAccess": "tree",
                 "wireDisplay": "default",
                 "sourceCount": 0,
                 "typeHintID": "pointcloud"


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/03832a64-a305-4bba-87b2-9d63edc465b0)

Tiny fix after meeting: The Cloud2Mesh component now handles the datatree correctly and converts properly rh to df_cloud.
This one is on me, I should not have touched a component handled by someone else, it creates confusion.

The only two files touched are the metadata and code of the DFCloud2Mesh component.