### PR TITLE
Fix: skip v1.3.1 following mismatch between manifest and tags in github dating back from may

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,6 @@
 ---
 name: diffCheck
-version: 1.3.2
+version: 1.3.1
 authors:
 - Andrea Settimi
 - Damien Gilliard


### PR DESCRIPTION
a 1.3.1 tag from 28th of may did not include an update of the version to the manifest.yml: https://github.com/diffCheckOrg/diffCheck/releases/tag/v1.3.1, leading to issues when creating new release because the manifest does not contain the new version number and the versionize invoke fails due to no difference in previous and new version number.